### PR TITLE
Environment Variable Support POC to rust Core

### DIFF
--- a/backlog.md
+++ b/backlog.md
@@ -5,6 +5,7 @@ Current feature backlog of tasks to do
 - Support for more complex property names
 - Yaml Config Source support
 - dotenv config source support
+- Read config files from path
 - Data Type converter support
 - more complex config builder
 - Expose Basic interface in python

--- a/backlog.md
+++ b/backlog.md
@@ -1,0 +1,13 @@
+# Backlog
+
+Current feature backlog of tasks to do
+
+- Support for more complex property names
+- Yaml Config Source support
+- dotenv config source support
+- Data Type converter support
+- more complex config builder
+- Expose Basic interface in python
+- launch on cargo & pypi
+- config profiles
+- secret handling

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -8,6 +8,7 @@ members = [
 
 [workspace.dependencies]
 cargo-audit = "0.20.1"
+rstest = "0.23.0"
 
 [patch.crates-io]
 # We are patching numpy with the latest main because there is currently a bug

--- a/rust/configler-core/Cargo.toml
+++ b/rust/configler-core/Cargo.toml
@@ -8,3 +8,6 @@ name = "configler_core"
 
 [dev-dependencies]
 cargo-audit.workspace = true
+
+[dependencies]
+dyn-clone = "1.0.17"

--- a/rust/configler-core/Cargo.toml
+++ b/rust/configler-core/Cargo.toml
@@ -8,6 +8,7 @@ name = "configler_core"
 
 [dev-dependencies]
 cargo-audit.workspace = true
+rstest.workspace = true
 
 [dependencies]
 dyn-clone = "1.0.17"

--- a/rust/configler-core/src/lib.rs
+++ b/rust/configler-core/src/lib.rs
@@ -20,7 +20,6 @@ dyn_clone::clone_trait_object!(ConfigSource);
 struct EnvironmentConfigSource {}
 
 impl EnvironmentConfigSource {
-
     #![allow(dead_code)]
     fn convert_property_to_environment_name(&self, property_name: &str) -> String {
         // TODO add more conversion rules
@@ -51,7 +50,6 @@ struct Config {
 }
 
 impl Config {
-
     #![allow(dead_code)]
     fn get_value(&self, property_name: &str) -> Option<String> {
         for config_source in self.sources.iter() {
@@ -116,7 +114,10 @@ mod tests {
     // #[case("foo.bar-baz", "FOO_BAR_BAZ")]
     // #[case("foo.bar[0]", "FOO_BAR_0_")]
     // #[case("foo.bar[0].baz", "FOO_BAR_0__BAZ")]
-    fn convert_property_to_environment_name(#[case] property_name: String, #[case] expected_env_name: String) {
+    fn convert_property_to_environment_name(
+        #[case] property_name: String,
+        #[case] expected_env_name: String,
+    ) {
         let config_source = EnvironmentConfigSource {};
         let env_name = config_source.convert_property_to_environment_name(&property_name);
         assert_eq!(expected_env_name, env_name);

--- a/rust/configler-core/src/lib.rs
+++ b/rust/configler-core/src/lib.rs
@@ -8,6 +8,7 @@ pub fn sum_as_string(a: usize, b: usize) -> String {
 }
 
 trait ConfigSource: DynClone {
+    #![allow(dead_code)]
     fn get_ordinal(&self) -> usize;
     fn get_value(&self, property_name: &str) -> Option<String>;
     fn get_name(&self) -> &str;
@@ -19,6 +20,8 @@ dyn_clone::clone_trait_object!(ConfigSource);
 struct EnvironmentConfigSource {}
 
 impl EnvironmentConfigSource {
+
+    #![allow(dead_code)]
     fn convert_property_to_environment_name(&self, property_name: &str) -> String {
         // TODO add more conversion rules
         // https://smallrye.io/smallrye-config/Main/config/environment-variables/
@@ -48,6 +51,8 @@ struct Config {
 }
 
 impl Config {
+
+    #![allow(dead_code)]
     fn get_value(&self, property_name: &str) -> Option<String> {
         for config_source in self.sources.iter() {
             let value = config_source.get_value(property_name);
@@ -71,6 +76,7 @@ struct ConfigBuilder {
 }
 
 impl ConfigBuilder {
+    #![allow(dead_code)]
     fn new() -> ConfigBuilder {
         ConfigBuilder {
             sources: Vec::new(),

--- a/rust/configler-core/src/lib.rs
+++ b/rust/configler-core/src/lib.rs
@@ -20,6 +20,8 @@ struct EnvironmentConfigSource {}
 
 impl EnvironmentConfigSource {
     fn convert_property_to_environment_name(&self, property_name: &str) -> String {
+        // TODO add more conversion rules
+        // https://smallrye.io/smallrye-config/Main/config/environment-variables/
         str::replace(&property_name.to_uppercase(), ".", "_")
     }
 }
@@ -89,6 +91,8 @@ impl ConfigBuilder {
 
 #[cfg(test)]
 mod tests {
+    use rstest::*;
+
     use super::*;
 
     #[test]
@@ -97,11 +101,19 @@ mod tests {
         assert_eq!(result, "5");
     }
 
-    #[test]
-    fn convert_property_to_environment_name() {
+    #[rstest]
+    #[case("TEST.ONE", "TEST_ONE")]
+    #[case("test.ONE", "TEST_ONE")]
+    #[case("foo", "FOO")]
+    // TODO adding more conversion rules
+    // #[case("foo.\"bar\".baz", "FOO__BAR__BAZ")]
+    // #[case("foo.bar-baz", "FOO_BAR_BAZ")]
+    // #[case("foo.bar[0]", "FOO_BAR_0_")]
+    // #[case("foo.bar[0].baz", "FOO_BAR_0__BAZ")]
+    fn convert_property_to_environment_name(#[case] property_name: String, #[case] expected_env_name: String) {
         let config_source = EnvironmentConfigSource {};
-        let env_name = config_source.convert_property_to_environment_name("test.one");
-        assert_eq!(env_name, "TEST_ONE");
+        let env_name = config_source.convert_property_to_environment_name(&property_name);
+        assert_eq!(expected_env_name, env_name);
     }
 
     #[test]
@@ -114,6 +126,16 @@ mod tests {
         assert_eq!(value.unwrap(), "blah");
 
         env::remove_var("TEST_ONE");
+    }
+
+    #[test]
+    fn use_default_value() {
+        // In this test the environment variable is not set
+        let config = ConfigBuilder::new().add_default_sources().build();
+
+        let default_value = "default_value";
+        let value = config.get_value_or_default("test.two", default_value.to_string());
+        assert_eq!(value, default_value.to_string())
     }
 
     #[test]

--- a/rust/configler-core/src/lib.rs
+++ b/rust/configler-core/src/lib.rs
@@ -1,6 +1,62 @@
+use std::env;
+
 // sum 2 values and return string
 pub fn sum_as_string(a: usize, b: usize) -> String {
     (a + b).to_string()
+}
+
+trait ConfigSource {
+    fn get_ordinal(&self) -> usize;
+    fn get_value(&self, property_name: String) -> Option<String>;
+    fn get_name(&self) -> &str;
+}
+
+struct EnvironmentConfigSource {}
+
+impl EnvironmentConfigSource {
+    fn convert_property_to_environment_name(&self, property_name: String) -> String {
+        str::replace(&property_name.to_uppercase(), ".", "_")
+    }
+}
+
+impl ConfigSource for EnvironmentConfigSource {
+    fn get_ordinal(&self) -> usize {
+        300
+    }
+    
+    fn get_value(&self, property_name: String) -> Option<String> {
+        match env::var(self.convert_property_to_environment_name(property_name)) {
+            Ok(value) => Some(value),
+            Err(_) => None
+        }
+    }
+
+    fn get_name(&self) -> &str {
+        std::any::type_name::<EnvironmentConfigSource>()
+    }
+}
+
+struct Config {
+    sources: Vec<Box<dyn ConfigSource>>
+}
+
+impl Config {
+    fn get_value(&self, property_name: &str) -> Option<String> {
+        for config_source in self.sources.iter() {
+            let value = config_source.get_value(property_name);
+            if value.is_some() {
+                return value
+            }
+        }
+        None
+    }
+
+    fn get_value_or_default(&self, property_name: &str, default: String) -> String {
+        match self.get_value(property_name) {
+            Some(value) => value,
+            None => default
+        }
+    }
 }
 
 #[cfg(test)]
@@ -11,5 +67,24 @@ mod tests {
     fn it_works() {
         let result = sum_as_string(3, 2);
         assert_eq!(result, "5");
+    }
+
+    #[test]
+    fn convert_property_to_environment_name() {
+        let config_source = EnvironmentConfigSource{};
+        let env_name = config_source.convert_property_to_environment_name("test.one".to_string());
+        assert_eq!(env_name, "TEST_ONE");
+    }
+
+    #[test]
+    fn read_environment_variable() {
+        env::set_var("TEST_ONE", "blah");
+
+        let config_source = EnvironmentConfigSource{};
+        let value = config_source.get_value("test.one".to_string());
+        assert_ne!(value, None);
+        assert_eq!(value.unwrap(), "blah");
+
+        env::remove_var("TEST_ONE");
     }
 }

--- a/rust/configler-core/src/lib.rs
+++ b/rust/configler-core/src/lib.rs
@@ -1,20 +1,25 @@
 use std::env;
 
+use dyn_clone::DynClone;
+
 // sum 2 values and return string
 pub fn sum_as_string(a: usize, b: usize) -> String {
     (a + b).to_string()
 }
 
-trait ConfigSource {
+trait ConfigSource: DynClone {
     fn get_ordinal(&self) -> usize;
-    fn get_value(&self, property_name: String) -> Option<String>;
+    fn get_value(&self, property_name: &str) -> Option<String>;
     fn get_name(&self) -> &str;
 }
 
+dyn_clone::clone_trait_object!(ConfigSource);
+
+#[derive(Clone)]
 struct EnvironmentConfigSource {}
 
 impl EnvironmentConfigSource {
-    fn convert_property_to_environment_name(&self, property_name: String) -> String {
+    fn convert_property_to_environment_name(&self, property_name: &str) -> String {
         str::replace(&property_name.to_uppercase(), ".", "_")
     }
 }
@@ -23,11 +28,11 @@ impl ConfigSource for EnvironmentConfigSource {
     fn get_ordinal(&self) -> usize {
         300
     }
-    
-    fn get_value(&self, property_name: String) -> Option<String> {
+
+    fn get_value(&self, property_name: &str) -> Option<String> {
         match env::var(self.convert_property_to_environment_name(property_name)) {
             Ok(value) => Some(value),
-            Err(_) => None
+            Err(_) => None,
         }
     }
 
@@ -37,7 +42,7 @@ impl ConfigSource for EnvironmentConfigSource {
 }
 
 struct Config {
-    sources: Vec<Box<dyn ConfigSource>>
+    sources: Vec<Box<dyn ConfigSource>>,
 }
 
 impl Config {
@@ -45,7 +50,7 @@ impl Config {
         for config_source in self.sources.iter() {
             let value = config_source.get_value(property_name);
             if value.is_some() {
-                return value
+                return value;
             }
         }
         None
@@ -54,7 +59,30 @@ impl Config {
     fn get_value_or_default(&self, property_name: &str, default: String) -> String {
         match self.get_value(property_name) {
             Some(value) => value,
-            None => default
+            None => default,
+        }
+    }
+}
+
+struct ConfigBuilder {
+    sources: Vec<Box<dyn ConfigSource>>,
+}
+
+impl ConfigBuilder {
+    fn new() -> ConfigBuilder {
+        ConfigBuilder {
+            sources: Vec::new(),
+        }
+    }
+
+    fn add_default_sources(&mut self) -> &mut ConfigBuilder {
+        self.sources.push(Box::new(EnvironmentConfigSource {}));
+        self
+    }
+
+    fn build(&self) -> Config {
+        Config {
+            sources: self.sources.clone(),
         }
     }
 }
@@ -71,8 +99,8 @@ mod tests {
 
     #[test]
     fn convert_property_to_environment_name() {
-        let config_source = EnvironmentConfigSource{};
-        let env_name = config_source.convert_property_to_environment_name("test.one".to_string());
+        let config_source = EnvironmentConfigSource {};
+        let env_name = config_source.convert_property_to_environment_name("test.one");
         assert_eq!(env_name, "TEST_ONE");
     }
 
@@ -80,11 +108,23 @@ mod tests {
     fn read_environment_variable() {
         env::set_var("TEST_ONE", "blah");
 
-        let config_source = EnvironmentConfigSource{};
-        let value = config_source.get_value("test.one".to_string());
+        let config_source = EnvironmentConfigSource {};
+        let value = config_source.get_value("test.one");
         assert_ne!(value, None);
         assert_eq!(value.unwrap(), "blah");
 
+        env::remove_var("TEST_ONE");
+    }
+
+    #[test]
+    fn build_default_sources() {
+        env::set_var("TEST_ONE", "blah");
+
+        let config = ConfigBuilder::new().add_default_sources().build();
+
+        let value = config.get_value("test.one");
+        assert_ne!(value, None);
+        assert_eq!(value.unwrap(), "blah");
         env::remove_var("TEST_ONE");
     }
 }


### PR DESCRIPTION
<!-- Edit And Paste Into Pull Request Title
Issue-<Github Issue Number>: PR Title
-->

<!--NOTE THE GITHUB ISSUES THAT THIS PR CLOSES BELOW-->
closes #

### Changes
- Stubs out basic config source interface
- stubs out basic config interface
- Adds basic implementation for reading configuration from environment variables

### Context For Reviewers

This serves as a rough POC of what the configuration interface could look like for the first config source
