### PR TITLE
Add Dot Environment File Support to Core Rust

### DIFF
--- a/backlog.md
+++ b/backlog.md
@@ -2,10 +2,10 @@
 
 Current feature backlog of tasks to do
 
-- Support for more complex property names
-- Yaml Config Source support
 - dotenv config source support
 - Read config files from path
+- Yaml Config Source support
+- Support for more complex property names
 - Data Type converter support
 - more complex config builder
 - Expose Basic interface in python

--- a/backlog.md
+++ b/backlog.md
@@ -10,5 +10,7 @@ Current feature backlog of tasks to do
 - more complex config builder
 - Expose Basic interface in python
 - launch on cargo & pypi
+- config validator
+- support expressions
 - config profiles
 - secret handling

--- a/backlog.md
+++ b/backlog.md
@@ -2,7 +2,7 @@
 
 Current feature backlog of tasks to do
 
-- dotenv config source support
+- refactor source instantiation
 - Read config files from path
 - Yaml Config Source support
 - Support for more complex property names

--- a/rust/configler-core/Cargo.toml
+++ b/rust/configler-core/Cargo.toml
@@ -12,3 +12,4 @@ rstest.workspace = true
 
 [dependencies]
 dyn-clone = "1.0.17"
+regex = "1.11.1"

--- a/rust/configler-core/src/lib.rs
+++ b/rust/configler-core/src/lib.rs
@@ -1,5 +1,5 @@
 pub mod sources;
-use sources::{ConfigSource, EnvironmentConfigSource};
+use sources::{dot_env::DotEnvironmentConfigSource, ConfigSource, EnvironmentConfigSource};
 
 // sum 2 values and return string
 pub fn sum_as_string(a: usize, b: usize) -> String {
@@ -37,15 +37,27 @@ struct ConfigBuilder {
 impl ConfigBuilder {
     #![allow(dead_code)]
     fn new() -> ConfigBuilder {
+        // let environment = EnvironmentConfigSource{}
         ConfigBuilder {
             sources: Vec::new(),
         }
     }
 
-    fn add_default_sources(&mut self) -> &mut ConfigBuilder {
-        self.sources.push(Box::new(EnvironmentConfigSource {}));
+    fn add_source(&mut self, source: EnvironmentConfigSource) -> &mut ConfigBuilder {
+        self.sources.push(Box::new(source));
         self
     }
+
+    fn add_default_sources(&mut self) -> &mut ConfigBuilder {
+        self.add_source(EnvironmentConfigSource {  })
+    }
+
+    // TODO should be able to override config file path
+    // TODO should be able to set config file path environment variable name
+
+    // TODO this is where maybe it would be useful to separate out reading the config file out of source
+    // instantiation. So that you can customize the source file location as part of the builder and then
+    // when the configuration is built we maybe read the config files
 
     fn build(&self) -> Config {
         Config {

--- a/rust/configler-core/src/lib.rs
+++ b/rust/configler-core/src/lib.rs
@@ -1,48 +1,9 @@
-use std::env;
-
-use dyn_clone::DynClone;
+pub mod sources;
+use sources::{ConfigSource, EnvironmentConfigSource};
 
 // sum 2 values and return string
 pub fn sum_as_string(a: usize, b: usize) -> String {
     (a + b).to_string()
-}
-
-trait ConfigSource: DynClone {
-    #![allow(dead_code)]
-    fn get_ordinal(&self) -> usize;
-    fn get_value(&self, property_name: &str) -> Option<String>;
-    fn get_name(&self) -> &str;
-}
-
-dyn_clone::clone_trait_object!(ConfigSource);
-
-#[derive(Clone)]
-struct EnvironmentConfigSource {}
-
-impl EnvironmentConfigSource {
-    #![allow(dead_code)]
-    fn convert_property_to_environment_name(&self, property_name: &str) -> String {
-        // TODO add more conversion rules
-        // https://smallrye.io/smallrye-config/Main/config/environment-variables/
-        str::replace(&property_name.to_uppercase(), ".", "_")
-    }
-}
-
-impl ConfigSource for EnvironmentConfigSource {
-    fn get_ordinal(&self) -> usize {
-        300
-    }
-
-    fn get_value(&self, property_name: &str) -> Option<String> {
-        match env::var(self.convert_property_to_environment_name(property_name)) {
-            Ok(value) => Some(value),
-            Err(_) => None,
-        }
-    }
-
-    fn get_name(&self) -> &str {
-        std::any::type_name::<EnvironmentConfigSource>()
-    }
 }
 
 struct Config {
@@ -95,44 +56,13 @@ impl ConfigBuilder {
 
 #[cfg(test)]
 mod tests {
-    use rstest::*;
-
     use super::*;
+    use std::env;
 
     #[test]
     fn it_works() {
         let result = sum_as_string(3, 2);
         assert_eq!(result, "5");
-    }
-
-    #[rstest]
-    #[case("TEST.ONE", "TEST_ONE")]
-    #[case("test.ONE", "TEST_ONE")]
-    #[case("foo", "FOO")]
-    // TODO adding more conversion rules
-    // #[case("foo.\"bar\".baz", "FOO__BAR__BAZ")]
-    // #[case("foo.bar-baz", "FOO_BAR_BAZ")]
-    // #[case("foo.bar[0]", "FOO_BAR_0_")]
-    // #[case("foo.bar[0].baz", "FOO_BAR_0__BAZ")]
-    fn convert_property_to_environment_name(
-        #[case] property_name: String,
-        #[case] expected_env_name: String,
-    ) {
-        let config_source = EnvironmentConfigSource {};
-        let env_name = config_source.convert_property_to_environment_name(&property_name);
-        assert_eq!(expected_env_name, env_name);
-    }
-
-    #[test]
-    fn read_environment_variable() {
-        env::set_var("TEST_ONE", "blah");
-
-        let config_source = EnvironmentConfigSource {};
-        let value = config_source.get_value("test.one");
-        assert_ne!(value, None);
-        assert_eq!(value.unwrap(), "blah");
-
-        env::remove_var("TEST_ONE");
     }
 
     #[test]

--- a/rust/configler-core/src/lib.rs
+++ b/rust/configler-core/src/lib.rs
@@ -1,5 +1,5 @@
 pub mod sources;
-use sources::{dot_env::DotEnvironmentConfigSource, ConfigSource, EnvironmentConfigSource};
+use sources::{ConfigSource, EnvironmentConfigSource};
 
 // sum 2 values and return string
 pub fn sum_as_string(a: usize, b: usize) -> String {
@@ -49,7 +49,7 @@ impl ConfigBuilder {
     }
 
     fn add_default_sources(&mut self) -> &mut ConfigBuilder {
-        self.add_source(EnvironmentConfigSource {  })
+        self.add_source(EnvironmentConfigSource {})
     }
 
     // TODO should be able to override config file path

--- a/rust/configler-core/src/sources/config_source.rs
+++ b/rust/configler-core/src/sources/config_source.rs
@@ -8,3 +8,33 @@ pub trait ConfigSource: DynClone {
 }
 
 dyn_clone::clone_trait_object!(ConfigSource);
+
+pub fn convert_property_to_environment_name(property_name: &str) -> String {
+    // TODO add more conversion rules
+    // https://smallrye.io/smallrye-config/Main/config/environment-variables/
+    str::replace(&property_name.to_uppercase(), ".", "_")
+}
+
+#[cfg(test)]
+mod tests {
+    use rstest::*;
+
+    use super::*;
+
+    #[rstest]
+    #[case("TEST.ONE", "TEST_ONE")]
+    #[case("test.ONE", "TEST_ONE")]
+    #[case("foo", "FOO")]
+    // TODO adding more conversion rules
+    // #[case("foo.\"bar\".baz", "FOO__BAR__BAZ")]
+    // #[case("foo.bar-baz", "FOO_BAR_BAZ")]
+    // #[case("foo.bar[0]", "FOO_BAR_0_")]
+    // #[case("foo.bar[0].baz", "FOO_BAR_0__BAZ")]
+    fn convert_property_to_environment_name_rules(
+        #[case] property_name: String,
+        #[case] expected_env_name: String,
+    ) {
+        let env_name = convert_property_to_environment_name(&property_name);
+        assert_eq!(expected_env_name, env_name);
+    }
+}

--- a/rust/configler-core/src/sources/config_source.rs
+++ b/rust/configler-core/src/sources/config_source.rs
@@ -1,0 +1,10 @@
+use dyn_clone::DynClone;
+
+pub trait ConfigSource: DynClone {
+    #![allow(dead_code)]
+    fn get_ordinal(&self) -> usize;
+    fn get_value(&self, property_name: &str) -> Option<String>;
+    fn get_name(&self) -> &str;
+}
+
+dyn_clone::clone_trait_object!(ConfigSource);

--- a/rust/configler-core/src/sources/dot_env.rs
+++ b/rust/configler-core/src/sources/dot_env.rs
@@ -1,0 +1,121 @@
+use super::ConfigSource;
+use std::{collections::HashMap, env, error::Error, str::FromStr};
+
+// https://www.dotenv.org/docs/security/env
+#[derive(Clone)]
+#[derive(Debug)]
+pub struct DotEnvironmentConfigSource {
+    // TODO I wonder if there is some value in separating the config source from actually storing
+    // config values in a map, hmm
+    values: HashMap<String, String>
+}
+
+impl ConfigSource for DotEnvironmentConfigSource {
+    fn get_ordinal(&self) -> usize {
+        295
+    }
+
+    fn get_value(&self, property_name: &str) -> Option<String> {
+        match env::var(self.convert_property_to_environment_name(property_name)) {
+            Ok(value) => Some(value),
+            Err(_) => None,
+        }
+    }
+
+    fn get_name(&self) -> &str {
+        // TODO check what this looks like
+        std::any::type_name::<DotEnvironmentConfigSource>()
+    }
+}
+
+impl DotEnvironmentConfigSource {
+
+    #![allow(dead_code)]
+    fn convert_property_to_environment_name(&self, property_name: &str) -> String {
+        // TODO add more conversion rules
+        // https://smallrye.io/smallrye-config/Main/config/environment-variables/
+        str::replace(&property_name.to_uppercase(), ".", "_")
+    }
+}
+
+impl FromStr for DotEnvironmentConfigSource {
+
+    fn from_str(dot_env_str: &str) -> Result<Self, Self::Err> {
+
+        let result_key_value_pairs = dot_env_str
+            .split("\n")
+            // Filter out records that should be skipped
+            .filter(|&record| {
+                record.trim().chars().count() > 0
+            })
+            // Map record into key value pairs
+            .map(|record| {
+                let tokens = record.split('=').collect::<Vec<&str>>();
+                if tokens.len() < 2 {
+                    //TODO figure out how to add indices to error message
+                    return Err("Record has invalid '=' operand")
+                } else {
+                    let key = tokens[0].trim();
+                    let value = tokens[1].trim();
+                    return Ok((key, value))
+                }
+            })
+            .collect::<Vec<Result<(&str, &str), _>>>();
+
+        let mut key_value_map: HashMap<String, String> = HashMap::new();
+        for result_pair in result_key_value_pairs {
+            if result_pair.is_err() {
+                return Err(result_pair.err().unwrap().to_string())
+            } else {
+                let pair = result_pair.unwrap();
+                key_value_map.insert(pair.0.to_owned(), pair.1.to_owned());
+            }
+        }
+        Ok(DotEnvironmentConfigSource {
+            values: key_value_map
+        })
+    }
+    
+    type Err = String;
+}
+
+#[cfg(test)]
+mod tests {
+    use rstest::*;
+
+    use super::*;
+
+    #[test]
+    fn parse_simple_dot_env_string() {
+        let dot_env_str = "
+        FIRST=one
+        FIRST_FOO=one
+        ";
+
+        let dot_env_source_result = DotEnvironmentConfigSource::from_str(dot_env_str);
+        assert_eq!(dot_env_source_result.clone().err(), None);
+
+        let dot_env_source = dot_env_source_result.unwrap();
+        assert_eq!(dot_env_source.values.len(), 2);
+    }
+
+    #[test]
+    fn parse_dot_env_string() {
+        let dot_env_str = "
+        FIRST=one
+        FIRST_FOO=one
+        # COMMENT
+        export SECOND=three
+        SPACE = space value
+        QUOTED = \"quote value\"
+
+        SECOND=second
+        ";
+
+        let dot_env_source_result = DotEnvironmentConfigSource::from_str(dot_env_str);
+        assert_eq!(dot_env_source_result.clone().err(), None);
+
+        let dot_env_source = dot_env_source_result.unwrap();
+        assert_eq!(dot_env_source.values.len(), 2);
+    }
+}

--- a/rust/configler-core/src/sources/dot_env.rs
+++ b/rust/configler-core/src/sources/dot_env.rs
@@ -8,7 +8,7 @@ use std::{collections::HashMap, fs, str::FromStr};
 #[allow(dead_code)]
 pub struct DotEnvironmentConfigSource {
     // TODO I wonder if there is some value in separating the config source from actually storing
-    // config values in a map, hmm
+    // config values in a map, hmm --> Yes
     values: HashMap<String, String>,
 }
 

--- a/rust/configler-core/src/sources/dot_env.rs
+++ b/rust/configler-core/src/sources/dot_env.rs
@@ -1,4 +1,4 @@
-use super::ConfigSource;
+use super::{config_source::convert_property_to_environment_name, ConfigSource};
 use core::fmt;
 use regex::Regex;
 use std::{collections::HashMap, fs, str::FromStr};
@@ -18,7 +18,7 @@ impl ConfigSource for DotEnvironmentConfigSource {
     }
 
     fn get_value(&self, property_name: &str) -> Option<String> {
-        let key = self.convert_property_to_environment_name(property_name);
+        let key = convert_property_to_environment_name(property_name);
         self.values.get(&key).map(|value| value.to_string())
     }
 
@@ -30,15 +30,8 @@ impl ConfigSource for DotEnvironmentConfigSource {
     }
 }
 
+#[allow(dead_code)]
 impl DotEnvironmentConfigSource {
-    #![allow(dead_code)]
-    fn convert_property_to_environment_name(&self, property_name: &str) -> String {
-        // TODO add more conversion rules
-        // TODO may also want to refactor this since it's a copy & paste from environment.rs
-        // https://smallrye.io/smallrye-config/Main/config/environment-variables/
-        str::replace(&property_name.to_uppercase(), ".", "_")
-    }
-
     fn from_file(file_path: &str) -> Result<Self, DotEnvFileError> {
         match fs::read_to_string(file_path) {
             Err(error) => Err(DotEnvFileError::IoError(error)),

--- a/rust/configler-core/src/sources/dot_env.rs
+++ b/rust/configler-core/src/sources/dot_env.rs
@@ -2,12 +2,11 @@ use super::ConfigSource;
 use std::{collections::HashMap, env, error::Error, str::FromStr};
 
 // https://www.dotenv.org/docs/security/env
-#[derive(Clone)]
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct DotEnvironmentConfigSource {
     // TODO I wonder if there is some value in separating the config source from actually storing
     // config values in a map, hmm
-    values: HashMap<String, String>
+    values: HashMap<String, String>,
 }
 
 impl ConfigSource for DotEnvironmentConfigSource {
@@ -29,7 +28,6 @@ impl ConfigSource for DotEnvironmentConfigSource {
 }
 
 impl DotEnvironmentConfigSource {
-
     #![allow(dead_code)]
     fn convert_property_to_environment_name(&self, property_name: &str) -> String {
         // TODO add more conversion rules
@@ -39,9 +37,8 @@ impl DotEnvironmentConfigSource {
 }
 
 impl FromStr for DotEnvironmentConfigSource {
-
     fn from_str(dot_env_str: &str) -> Result<Self, Self::Err> {
-
+        // TODO break up pipeline into parsing functions?
         let result_key_value_pairs = dot_env_str
             .split("\n")
             // enumerate records into line_no & record
@@ -57,9 +54,16 @@ impl FromStr for DotEnvironmentConfigSource {
             .map(|(line_no, record)| {
                 let tokens = record.split('=').collect::<Vec<&str>>();
                 if tokens.len() < 2 {
-                    return Err(format!("At Line {}, Record has invalid '=' operand", line_no))
+                    return Err(format!(
+                        "At Line {}, Record has invalid '=' operand",
+                        line_no
+                    ));
                 } else {
-                    let key = tokens[0].trim().trim_start_matches("export ").trim();
+                    let key = tokens[0]
+                        .trim()
+                        .trim_start_matches("export ")
+                        .trim()
+                        .to_uppercase();
 
                     let temp_value = tokens[1].trim();
                     let value: &str;
@@ -69,32 +73,48 @@ impl FromStr for DotEnvironmentConfigSource {
                         value = temp_value;
                     }
 
-                    return Ok((key, value))
+                    if key.len() == 0 {
+                        return Err(format!("At Line {}, Key is empty", line_no));
+                    }
+                    if value.len() == 0 {
+                        return Err(format!("At Line {}, value is empty", line_no));
+                    }
+
+                    return Ok((key, value));
                 }
             })
-            .collect::<Vec<Result<(&str, &str), _>>>();
+            .collect::<Vec<Result<(String, &str), _>>>();
 
+        let mut error_message = "".to_owned();
         let mut key_value_map: HashMap<String, String> = HashMap::new();
         for result_pair in result_key_value_pairs {
             if result_pair.is_err() {
-                return Err(result_pair.err().unwrap().to_string())
+                if error_message.len() > 0 {
+                    error_message.push_str("\n");
+                }
+                error_message.push_str(&result_pair.err().unwrap().to_string());
+                // return Err(result_pair.err().unwrap().to_string())
             } else {
                 let pair = result_pair.unwrap();
                 key_value_map.insert(pair.0.to_owned(), pair.1.to_owned());
             }
         }
-        Ok(DotEnvironmentConfigSource {
-            values: key_value_map
-        })
+
+        if error_message.len() > 0 {
+            Err(error_message)
+        } else {
+            Ok(DotEnvironmentConfigSource {
+                values: key_value_map,
+            })
+        }
     }
-    
+
+    // TODO should there be a custom Error Type?
     type Err = String;
 }
 
 #[cfg(test)]
 mod tests {
-    use rstest::*;
-
     use super::*;
 
     #[test]
@@ -113,8 +133,17 @@ mod tests {
         assert_eq!(dot_env_source.values.len(), 2);
 
         // verify key values
-        assert_eq!(dot_env_source.values.get("FIRST").map(|s| s.to_string()), Some("one".to_string()));
-        assert_eq!(dot_env_source.values.get("FIRST_FOO").map(|s| s.to_string()), Some("one foo".to_string()));
+        assert_eq!(
+            dot_env_source.values.get("FIRST").map(|s| s.to_string()),
+            Some("one".to_string())
+        );
+        assert_eq!(
+            dot_env_source
+                .values
+                .get("FIRST_FOO")
+                .map(|s| s.to_string()),
+            Some("one foo".to_string())
+        );
     }
 
     #[test]
@@ -138,14 +167,69 @@ mod tests {
         assert_eq!(dot_env_source.values.len(), 7);
 
         // verify key values
-        assert_eq!(dot_env_source.values.get("FIRST").map(|s| s.to_string()), Some("one".to_string()));
-        assert_eq!(dot_env_source.values.get("SECOND").map(|s| s.to_string()), Some("second value".to_string()));
-        assert_eq!(dot_env_source.values.get("SPACE").map(|s| s.to_string()), Some("space value".to_string()));
-        assert_eq!(dot_env_source.values.get("QUOTED").map(|s| s.to_string()), Some("quote value".to_string()));
-        assert_eq!(dot_env_source.values.get("THIRD").map(|s| s.to_string()), Some("third".to_string()));
-        // assert_eq!(dot_env_source.values.get("LOWER").map(|s| s.to_string()), Some("lower value".to_string()));
-        assert_eq!(dot_env_source.values.get("UPPER").map(|s| s.to_string()), Some("UPPER VALUE".to_string()));
+        assert_eq!(
+            dot_env_source.values.get("FIRST").map(|s| s.to_string()),
+            Some("one".to_string())
+        );
+        assert_eq!(
+            dot_env_source.values.get("SECOND").map(|s| s.to_string()),
+            Some("second value".to_string())
+        );
+        assert_eq!(
+            dot_env_source.values.get("SPACE").map(|s| s.to_string()),
+            Some("space value".to_string())
+        );
+        assert_eq!(
+            dot_env_source.values.get("QUOTED").map(|s| s.to_string()),
+            Some("quote value".to_string())
+        );
+        assert_eq!(
+            dot_env_source.values.get("THIRD").map(|s| s.to_string()),
+            Some("third".to_string())
+        );
+        assert_eq!(
+            dot_env_source.values.get("LOWER").map(|s| s.to_string()),
+            Some("fourth value".to_string())
+        );
+        assert_eq!(
+            dot_env_source.values.get("UPPER").map(|s| s.to_string()),
+            Some("UPPER VALUE".to_string())
+        );
+    }
+
+    #[test]
+    fn parse_invalid_dot_env_error() {
+        let dot_env_str = "
+        FIRST=one
+        BAD_FOO=
+        SECOND=la
+        ";
+
+        // Verify parsing error
+        let dot_env_source_result = DotEnvironmentConfigSource::from_str(dot_env_str);
+        assert_eq!(
+            dot_env_source_result.clone().err(),
+            Some("At Line 2, value is empty".to_string())
+        );
+    }
+
+    #[test]
+    fn parse_multiple_dot_env_errors() {
+        let dot_env_str = "
+        FIRST=one
+        BAD_FOO=
+        SECOND=la
+        =blah
+        ";
+
+        // Verify parsing error
+        let dot_env_source_result = DotEnvironmentConfigSource::from_str(dot_env_str);
+        assert_eq!(
+            dot_env_source_result.clone().err(),
+            Some("At Line 2, value is empty\nAt Line 4, Key is empty".to_string())
+        );
     }
 
     // TODO test multiline input
+    //TODO test source name
 }

--- a/rust/configler-core/src/sources/environment.rs
+++ b/rust/configler-core/src/sources/environment.rs
@@ -1,0 +1,68 @@
+use super::ConfigSource;
+use std::env;
+
+#[derive(Clone)]
+pub struct EnvironmentConfigSource {}
+
+impl EnvironmentConfigSource {
+    #![allow(dead_code)]
+    fn convert_property_to_environment_name(&self, property_name: &str) -> String {
+        // TODO add more conversion rules
+        // https://smallrye.io/smallrye-config/Main/config/environment-variables/
+        str::replace(&property_name.to_uppercase(), ".", "_")
+    }
+}
+
+impl ConfigSource for EnvironmentConfigSource {
+    fn get_ordinal(&self) -> usize {
+        300
+    }
+
+    fn get_value(&self, property_name: &str) -> Option<String> {
+        match env::var(self.convert_property_to_environment_name(property_name)) {
+            Ok(value) => Some(value),
+            Err(_) => None,
+        }
+    }
+
+    fn get_name(&self) -> &str {
+        std::any::type_name::<EnvironmentConfigSource>()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use rstest::*;
+
+    use super::*;
+
+    #[rstest]
+    #[case("TEST.ONE", "TEST_ONE")]
+    #[case("test.ONE", "TEST_ONE")]
+    #[case("foo", "FOO")]
+    // TODO adding more conversion rules
+    // #[case("foo.\"bar\".baz", "FOO__BAR__BAZ")]
+    // #[case("foo.bar-baz", "FOO_BAR_BAZ")]
+    // #[case("foo.bar[0]", "FOO_BAR_0_")]
+    // #[case("foo.bar[0].baz", "FOO_BAR_0__BAZ")]
+    fn convert_property_to_environment_name(
+        #[case] property_name: String,
+        #[case] expected_env_name: String,
+    ) {
+        let config_source = EnvironmentConfigSource {};
+        let env_name = config_source.convert_property_to_environment_name(&property_name);
+        assert_eq!(expected_env_name, env_name);
+    }
+
+    #[test]
+    fn read_environment_variable() {
+        env::set_var("TEST_ONE", "blah");
+
+        let config_source = EnvironmentConfigSource {};
+        let value = config_source.get_value("test.one");
+        assert_ne!(value, None);
+        assert_eq!(value.unwrap(), "blah");
+
+        env::remove_var("TEST_ONE");
+    }
+}

--- a/rust/configler-core/src/sources/environment.rs
+++ b/rust/configler-core/src/sources/environment.rs
@@ -26,7 +26,10 @@ impl ConfigSource for EnvironmentConfigSource {
     }
 
     fn get_name(&self) -> &str {
-        std::any::type_name::<EnvironmentConfigSource>().split("::").last().unwrap()
+        std::any::type_name::<EnvironmentConfigSource>()
+            .split("::")
+            .last()
+            .unwrap()
     }
 }
 

--- a/rust/configler-core/src/sources/environment.rs
+++ b/rust/configler-core/src/sources/environment.rs
@@ -1,17 +1,10 @@
-use super::ConfigSource;
+use super::{config_source::convert_property_to_environment_name, ConfigSource};
 use std::env;
 
 #[derive(Clone)]
 pub struct EnvironmentConfigSource {}
 
-impl EnvironmentConfigSource {
-    #![allow(dead_code)]
-    fn convert_property_to_environment_name(&self, property_name: &str) -> String {
-        // TODO add more conversion rules
-        // https://smallrye.io/smallrye-config/Main/config/environment-variables/
-        str::replace(&property_name.to_uppercase(), ".", "_")
-    }
-}
+impl EnvironmentConfigSource {}
 
 impl ConfigSource for EnvironmentConfigSource {
     fn get_ordinal(&self) -> usize {
@@ -19,7 +12,7 @@ impl ConfigSource for EnvironmentConfigSource {
     }
 
     fn get_value(&self, property_name: &str) -> Option<String> {
-        match env::var(self.convert_property_to_environment_name(property_name)) {
+        match env::var(convert_property_to_environment_name(property_name)) {
             Ok(value) => Some(value),
             Err(_) => None,
         }
@@ -35,27 +28,8 @@ impl ConfigSource for EnvironmentConfigSource {
 
 #[cfg(test)]
 mod tests {
-    use rstest::*;
 
     use super::*;
-
-    #[rstest]
-    #[case("TEST.ONE", "TEST_ONE")]
-    #[case("test.ONE", "TEST_ONE")]
-    #[case("foo", "FOO")]
-    // TODO adding more conversion rules
-    // #[case("foo.\"bar\".baz", "FOO__BAR__BAZ")]
-    // #[case("foo.bar-baz", "FOO_BAR_BAZ")]
-    // #[case("foo.bar[0]", "FOO_BAR_0_")]
-    // #[case("foo.bar[0].baz", "FOO_BAR_0__BAZ")]
-    fn convert_property_to_environment_name(
-        #[case] property_name: String,
-        #[case] expected_env_name: String,
-    ) {
-        let config_source = EnvironmentConfigSource {};
-        let env_name = config_source.convert_property_to_environment_name(&property_name);
-        assert_eq!(expected_env_name, env_name);
-    }
 
     #[test]
     fn read_environment_variable() {

--- a/rust/configler-core/src/sources/environment.rs
+++ b/rust/configler-core/src/sources/environment.rs
@@ -26,7 +26,7 @@ impl ConfigSource for EnvironmentConfigSource {
     }
 
     fn get_name(&self) -> &str {
-        std::any::type_name::<EnvironmentConfigSource>()
+        std::any::type_name::<EnvironmentConfigSource>().split("::").last().unwrap()
     }
 }
 

--- a/rust/configler-core/src/sources/mod.rs
+++ b/rust/configler-core/src/sources/mod.rs
@@ -1,0 +1,5 @@
+pub mod config_source;
+pub mod environment;
+
+pub use self::config_source::ConfigSource;
+pub use self::environment::EnvironmentConfigSource;

--- a/rust/configler-core/src/sources/mod.rs
+++ b/rust/configler-core/src/sources/mod.rs
@@ -1,5 +1,6 @@
 pub mod config_source;
 pub mod environment;
+pub mod dot_env;
 
 pub use self::config_source::ConfigSource;
 pub use self::environment::EnvironmentConfigSource;

--- a/rust/configler-core/src/sources/mod.rs
+++ b/rust/configler-core/src/sources/mod.rs
@@ -1,6 +1,6 @@
 pub mod config_source;
-pub mod environment;
 pub mod dot_env;
+pub mod environment;
 
 pub use self::config_source::ConfigSource;
 pub use self::environment::EnvironmentConfigSource;

--- a/rust/configler-core/test.env
+++ b/rust/configler-core/test.env
@@ -1,1 +1,3 @@
+# This is a test dotenv file for use in testing
+
 KEY1=blah

--- a/rust/configler-core/test.env
+++ b/rust/configler-core/test.env
@@ -1,0 +1,1 @@
+KEY1=blah


### PR DESCRIPTION
<!-- Edit And Paste Into Pull Request Title
Issue-<Github Issue Number>: PR Title
-->

<!--NOTE THE GITHUB ISSUES THAT THIS PR CLOSES BELOW-->
closes #

### Changes
<!-- DESCRIBE THE CHANGES YOU ARE MAKING -->
- Refactors config sources to separate module
- Creates DotEnvironmentConfigSource that can read dot environment files
- Add shared utility for converting property names to environment variable names
- Add notes about when sources should be instantiated

### Context For Reviewers
This PR adds the second configuration source which is for .env files that are common among python & javascript projects. This is still part of the POC so interfaces may undergone more refactoring and documentation is still minimal. 

This PR does not hook up the new source to the builder. Since I am considering some refactoring next that will come later
