### PR TITLE
Expose Library functions as Public

### DIFF
--- a/backlog.md
+++ b/backlog.md
@@ -2,15 +2,17 @@
 
 Current feature backlog of tasks to do
 
-- Support for more complex property names
 - Data Type converter support
+- Support for more complex property names
 - more complex config builder
 - Expose Basic interface in python
 - add function docs
 - add get list support for all config sources
 - update readme with examples
 - Fix maturin build warnings
-- launch on cargo & pypi
+- launch on cargo
+- launch on pypi
+- release automation
 - mocking support
 - config validator
 - support expressions

--- a/backlog.md
+++ b/backlog.md
@@ -9,6 +9,7 @@ Current feature backlog of tasks to do
 - add function docs
 - add get list support for all config sources
 - update readme with examples
+- Fix maturin build warnings
 - launch on cargo & pypi
 - mocking support
 - config validator

--- a/backlog.md
+++ b/backlog.md
@@ -15,3 +15,5 @@ Current feature backlog of tasks to do
 - support expressions
 - config profiles
 - secret handling
+- add macro for configuration groups
+- configuration injection

--- a/rust/configler-core/src/lib.rs
+++ b/rust/configler-core/src/lib.rs
@@ -9,7 +9,7 @@ pub fn sum_as_string(a: usize, b: usize) -> String {
     (a + b).to_string()
 }
 
-struct Config {
+pub struct Config {
     sources: Vec<Box<dyn ConfigSource>>,
 }
 
@@ -35,13 +35,13 @@ impl Config {
 
 #[derive(Debug)]
 #[allow(dead_code)]
-enum SourceName {
+pub enum SourceName {
     Environment,
     DotEnvironmentFile,
     YamlFile,
 }
 
-struct ConfigBuilder {
+pub struct ConfigBuilder {
     instantiated_sources: Vec<Box<dyn ConfigSource>>,
     lazy_sources: Vec<SourceName>,
     config_directory: Option<String>,
@@ -49,7 +49,7 @@ struct ConfigBuilder {
 
 impl ConfigBuilder {
     #![allow(dead_code)]
-    fn new() -> ConfigBuilder {
+    pub fn new() -> ConfigBuilder {
         ConfigBuilder {
             instantiated_sources: Vec::new(),
             lazy_sources: Vec::new(),
@@ -57,7 +57,7 @@ impl ConfigBuilder {
         }
     }
 
-    fn set_config_directory(&mut self, config_directory: &str) -> &mut Self {
+    pub fn set_config_directory(&mut self, config_directory: &str) -> &mut Self {
         let mut directory = config_directory.to_owned();
         if !directory.ends_with("/") {
             directory += "/";
@@ -66,21 +66,21 @@ impl ConfigBuilder {
         self
     }
 
-    fn add_source(&mut self, name: SourceName) -> &mut Self {
+    pub fn add_source(&mut self, name: SourceName) -> &mut Self {
         self.lazy_sources.push(name);
         self
     }
 
-    fn add_custom_source(&mut self, source: Box<dyn ConfigSource>) -> &mut Self {
+    pub fn add_custom_source(&mut self, source: Box<dyn ConfigSource>) -> &mut Self {
         self.instantiated_sources.push(source);
         self
     }
 
-    fn add_default_sources(&mut self) -> &mut ConfigBuilder {
+    pub fn add_default_sources(&mut self) -> &mut ConfigBuilder {
         self.add_source(SourceName::Environment)
     }
 
-    fn build(&self) -> Result<Config, FileError> {
+    pub fn build(&self) -> Result<Config, FileError> {
         let mut final_sources = self.instantiated_sources.clone();
 
         if !self.lazy_sources.is_empty() {

--- a/rust/configler-core/src/lib.rs
+++ b/rust/configler-core/src/lib.rs
@@ -134,6 +134,11 @@ impl ConfigBuilder {
     }
 }
 
+impl Default for ConfigBuilder {
+    fn default() -> Self {
+        ConfigBuilder::new()
+    }
+}
 
 pub trait ConfigPropertyGroup<'a> {
     fn get_value_map(&self) -> Result<HashMap<String, Option<String>>, ConfigValueError>;
@@ -145,7 +150,7 @@ pub trait ConfigPropertyGroup<'a> {
 pub enum ConfigValueError {
     // TODO these are placeholders, will need to update these once we implement these
     TypeError,
-    NullError
+    NullError,
 }
 
 #[cfg(test)]

--- a/rust/configler-core/src/lib.rs
+++ b/rust/configler-core/src/lib.rs
@@ -1,4 +1,6 @@
 pub mod sources;
+use std::collections::HashMap;
+
 use sources::{
     config_source::FileError, dot_env::DotEnvironmentConfigSource, ConfigSource,
     EnvironmentConfigSource, YamlConfigSource,
@@ -130,6 +132,20 @@ impl ConfigBuilder {
             sources: final_sources,
         })
     }
+}
+
+
+pub trait ConfigPropertyGroup<'a> {
+    fn get_value_map(&self) -> Result<HashMap<String, Option<String>>, ConfigValueError>;
+
+    fn from_config(config: &'a Config) -> Self;
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum ConfigValueError {
+    // TODO these are placeholders, will need to update these once we implement these
+    TypeError,
+    NullError
 }
 
 #[cfg(test)]

--- a/rust/configler-core/src/lib.rs
+++ b/rust/configler-core/src/lib.rs
@@ -15,7 +15,7 @@ pub struct Config {
 
 impl Config {
     #![allow(dead_code)]
-    fn get_value(&self, property_name: &str) -> Option<String> {
+    pub fn get_value(&self, property_name: &str) -> Option<String> {
         for config_source in self.sources.iter() {
             let value = config_source.get_value(property_name);
             if value.is_some() {
@@ -25,7 +25,7 @@ impl Config {
         None
     }
 
-    fn get_value_or_default(&self, property_name: &str, default: String) -> String {
+    pub fn get_value_or_default(&self, property_name: &str, default: String) -> String {
         match self.get_value(property_name) {
             Some(value) => value,
             None => default,

--- a/rust/configler-core/src/lib.rs
+++ b/rust/configler-core/src/lib.rs
@@ -16,7 +16,6 @@ pub struct Config {
 }
 
 impl Config {
-    #![allow(dead_code)]
     pub fn get_value(&self, property_name: &str) -> Option<String> {
         for config_source in self.sources.iter() {
             let value = config_source.get_value(property_name);
@@ -36,7 +35,6 @@ impl Config {
 }
 
 #[derive(Debug)]
-#[allow(dead_code)]
 pub enum SourceName {
     Environment,
     DotEnvironmentFile,
@@ -50,7 +48,6 @@ pub struct ConfigBuilder {
 }
 
 impl ConfigBuilder {
-    #![allow(dead_code)]
     pub fn new() -> ConfigBuilder {
         ConfigBuilder {
             instantiated_sources: Vec::new(),

--- a/rust/configler-core/src/sources/config_source.rs
+++ b/rust/configler-core/src/sources/config_source.rs
@@ -6,7 +6,6 @@ use super::dot_env::DotEnvLineParseErrors;
 use super::yaml::YamlParseError;
 
 pub trait ConfigSource: DynClone {
-    #![allow(dead_code)]
     fn get_ordinal(&self) -> usize;
     fn get_value(&self, property_name: &str) -> Option<String>;
     fn get_name(&self) -> &str;

--- a/rust/configler-core/src/sources/dot_env.rs
+++ b/rust/configler-core/src/sources/dot_env.rs
@@ -8,7 +8,6 @@ use std::{collections::HashMap, fs, str::FromStr};
 
 // https://www.dotenv.org/docs/security/env
 #[derive(Clone, Debug)]
-#[allow(dead_code)]
 pub struct DotEnvironmentConfigSource {
     values: HashMap<String, String>,
 }

--- a/rust/configler-core/tests/api_tests.rs
+++ b/rust/configler-core/tests/api_tests.rs
@@ -1,6 +1,10 @@
 use std::{collections::HashMap, str::FromStr};
 
-use configler_core::{self, sources::{ConfigSource, YamlConfigSource}, Config, ConfigBuilder, ConfigPropertyGroup, ConfigValueError, SourceName};
+use configler_core::{
+    self,
+    sources::{ConfigSource, YamlConfigSource},
+    Config, ConfigBuilder, ConfigPropertyGroup, ConfigValueError, SourceName,
+};
 
 #[test]
 fn verify_lazy_builder_and_config_visibility() {
@@ -15,11 +19,14 @@ fn verify_lazy_builder_and_config_visibility() {
 
 #[test]
 fn verify_builder_custom_source_visibility() {
-    let yaml_source = YamlConfigSource::from_str("
+    let yaml_source = YamlConfigSource::from_str(
+        "
     database:
         user: baz
         password: foo
-    ").unwrap();
+    ",
+    )
+    .unwrap();
 
     let builder_result = ConfigBuilder::new()
         .add_custom_source(Box::new(yaml_source))
@@ -29,12 +36,14 @@ fn verify_builder_custom_source_visibility() {
 
     let config = builder_result.unwrap();
     assert_eq!(config.get_value("database.user"), Some("baz".to_string()));
-    assert_eq!(config.get_value_or_default("database.is_ssl", "true".to_string()), "true");
+    assert_eq!(
+        config.get_value_or_default("database.is_ssl", "true".to_string()),
+        "true"
+    );
 }
 
 #[test]
 fn verify_custom_source_works_with_builder() {
-
     #[derive(Clone)]
     struct CustomSource {}
 
@@ -42,40 +51,47 @@ fn verify_custom_source_works_with_builder() {
         fn get_ordinal(&self) -> usize {
             10
         }
-    
+
         fn get_value(&self, _property_name: &str) -> Option<String> {
             Some("example_value".to_string())
         }
-    
+
         fn get_name(&self) -> &str {
             "custom test source"
         }
-    
-        fn from_file(_file_path: &str) -> Result<Self, configler_core::sources::config_source::FileError>
+
+        fn from_file(
+            _file_path: &str,
+        ) -> Result<Self, configler_core::sources::config_source::FileError>
         where
-            Self: Sized {
-            Ok(CustomSource{})
+            Self: Sized,
+        {
+            Ok(CustomSource {})
         }
     }
 
     let builder_result = ConfigBuilder::new()
-        .add_custom_source(Box::new(CustomSource{}))
+        .add_custom_source(Box::new(CustomSource {}))
         .build();
     assert!(builder_result.is_ok());
 
     let config = builder_result.unwrap();
-    assert_eq!(config.get_value("any.value"), Some("example_value".to_string()));
-
+    assert_eq!(
+        config.get_value("any.value"),
+        Some("example_value".to_string())
+    );
 }
 
 #[test]
 fn verify_config_property_group_pattern() {
-
-    let yaml_source = YamlConfigSource::from_str("
+    let yaml_source = YamlConfigSource::from_str(
+        "
     database:
         user: baz
         password: foo
-    ").unwrap();
+    ",
+    )
+    .unwrap();
 
     let builder_result = ConfigBuilder::new()
         .add_custom_source(Box::new(yaml_source))
@@ -83,7 +99,7 @@ fn verify_config_property_group_pattern() {
     assert!(builder_result.is_ok());
 
     struct DbConfig<'a> {
-        config: &'a Config
+        config: &'a Config,
     }
     impl<'a> DbConfig<'a> {
         fn get_username(&self) -> Result<String, ConfigValueError> {
@@ -110,15 +126,13 @@ fn verify_config_property_group_pattern() {
             };
             match self.get_password() {
                 Ok(value) => value_map.insert("DATABASE_PASSWORD".to_string(), Some(value)),
-                Err(error) => return Err(error)
+                Err(error) => return Err(error),
             };
             Ok(value_map)
         }
-    
+
         fn from_config(config: &'a Config) -> Self {
-            DbConfig {
-                config
-            }
+            DbConfig { config }
         }
     }
 
@@ -136,6 +150,12 @@ fn verify_config_property_group_pattern() {
     assert!(value_map_result.is_ok());
 
     let value_map = value_map_result.unwrap();
-    assert_eq!(value_map.get("DATABASE_USER"), Some(&Some("baz".to_string())));
-    assert_eq!(value_map.get("DATABASE_PASSWORD"), Some(&Some("foo".to_string())));
+    assert_eq!(
+        value_map.get("DATABASE_USER"),
+        Some(&Some("baz".to_string()))
+    );
+    assert_eq!(
+        value_map.get("DATABASE_PASSWORD"),
+        Some(&Some("foo".to_string()))
+    );
 }

--- a/rust/configler-core/tests/api_tests.rs
+++ b/rust/configler-core/tests/api_tests.rs
@@ -1,16 +1,72 @@
-use configler_core;
+use std::str::FromStr;
+
+use configler_core::{self, sources::{ConfigSource, YamlConfigSource}, ConfigBuilder, SourceName};
 
 #[test]
 fn verify_lazy_builder_and_config_visibility() {
-    let builder_result = configler_core::ConfigBuilder::new()
-        .add_source(configler_core::SourceName::Environment)
-        .add_source(configler_core::SourceName::YamlFile)
+    let builder_result = ConfigBuilder::new()
+        .add_source(SourceName::Environment)
+        .add_source(SourceName::YamlFile)
         .set_config_directory("./test_configs")
         .build();
 
     assert!(builder_result.is_ok());
 }
 
-// TODO verify custom source config visibility
-// TODO verify new custom config sources can be added
+#[test]
+fn verify_builder_custom_source_visibility() {
+    let yaml_source = YamlConfigSource::from_str("
+    database:
+        user: baz
+        password: foo
+    ").unwrap();
+
+    let builder_result = ConfigBuilder::new()
+        .add_custom_source(Box::new(yaml_source))
+        .build();
+
+    assert!(builder_result.is_ok());
+
+    let config = builder_result.unwrap();
+    assert_eq!(config.get_value("database.user"), Some("baz".to_string()));
+    assert_eq!(config.get_value_or_default("database.is_ssl", "true".to_string()), "true");
+}
+
+#[test]
+fn verify_custom_source_works_with_builder() {
+
+    #[derive(Clone)]
+    struct CustomSource {}
+
+    impl ConfigSource for CustomSource {
+        fn get_ordinal(&self) -> usize {
+            10
+        }
+    
+        fn get_value(&self, _property_name: &str) -> Option<String> {
+            Some("example_value".to_string())
+        }
+    
+        fn get_name(&self) -> &str {
+            "custom test source"
+        }
+    
+        fn from_file(_file_path: &str) -> Result<Self, configler_core::sources::config_source::FileError>
+        where
+            Self: Sized {
+            Ok(CustomSource{})
+        }
+    }
+
+    let builder_result = ConfigBuilder::new()
+        .add_custom_source(Box::new(CustomSource{}))
+        .build();
+    assert!(builder_result.is_ok());
+
+    let config = builder_result.unwrap();
+    assert_eq!(config.get_value("any.value"), Some("example_value".to_string()));
+
+}
+
+
 // TODO verify pattern with sub config sources is possible

--- a/rust/configler-core/tests/api_tests.rs
+++ b/rust/configler-core/tests/api_tests.rs
@@ -137,8 +137,6 @@ fn verify_config_property_group_pattern() {
     }
 
     let base_config = builder_result.unwrap();
-    //TODO this pattern encourages shared references, which I don't think rust supports
-    // may need to look into that a bit
     let db_config = DbConfig::from_config(&base_config);
 
     assert!(db_config.get_username().is_ok());

--- a/rust/configler-core/tests/api_tests.rs
+++ b/rust/configler-core/tests/api_tests.rs
@@ -1,0 +1,16 @@
+use configler_core;
+
+#[test]
+fn verify_lazy_builder_and_config_visibility() {
+    let builder_result = configler_core::ConfigBuilder::new()
+        .add_source(configler_core::SourceName::Environment)
+        .add_source(configler_core::SourceName::YamlFile)
+        .set_config_directory("./test_configs")
+        .build();
+
+    assert!(builder_result.is_ok());
+}
+
+// TODO verify custom source config visibility
+// TODO verify new custom config sources can be added
+// TODO verify pattern with sub config sources is possible


### PR DESCRIPTION
<!-- Edit And Paste Into Pull Request Title
Issue-<Github Issue Number>: PR Title
-->

<!--NOTE THE GITHUB ISSUES THAT THIS PR CLOSES BELOW-->
closes #

### Changes
<!-- DESCRIBE THE CHANGES YOU ARE MAKING -->
- Updates config and builder contructs to be public
- Adds ConfigPropertyGroup trait to encourage grouping configuration
- Adds integration tests that demonstrate potential use cases
- Adds ConfigValueError Enum to track errors while mapping configuration groups
- removes dead code suppressions

### Context For Reviewers
<!-- WHY ARE YOU MAKING THIS CHANGE? -->
This PR sets up some examples of using the core rust library in the form of integration tests & makes several tweaks based on those initial learnings.

