### PR TITLE
Pin Maturin Version

### DIFF
--- a/.github/workflows/python-maturin-ci.yml
+++ b/.github/workflows/python-maturin-ci.yml
@@ -53,6 +53,7 @@ jobs:
         uses: PyO3/maturin-action@v1
         with:
           target: ${{ matrix.platform.target }}
+          maturin-version: "1.7.4"
           args: --release --out dist --find-interpreter
           sccache: 'true'
           manylinux: auto
@@ -88,6 +89,7 @@ jobs:
         uses: PyO3/maturin-action@v1
         with:
           target: ${{ matrix.platform.target }}
+          maturin-version: "1.7.4"
           args: --release --out dist --find-interpreter
           sccache: 'true'
           manylinux: musllinux_1_2
@@ -120,6 +122,7 @@ jobs:
         uses: PyO3/maturin-action@v1
         with:
           target: ${{ matrix.platform.target }}
+          maturin-version: "1.7.4"
           args: --release --out dist --find-interpreter
           sccache: 'true'
           working-directory: ./rust/configler-pyo3
@@ -150,6 +153,7 @@ jobs:
         uses: PyO3/maturin-action@v1
         with:
           target: ${{ matrix.platform.target }}
+          maturin-version: "1.7.4"
           args: --release --out dist --find-interpreter
           sccache: 'true'
           working-directory: ./rust/configler-pyo3
@@ -177,6 +181,7 @@ jobs:
         uses: PyO3/maturin-action@v1
         with:
           command: sdist
+          maturin-version: "1.7.4"
           args: --out dist
           working-directory: ./rust/configler-pyo3
       - name: Upload sdist
@@ -213,4 +218,5 @@ jobs:
           MATURIN_PYPI_TOKEN: ${{ secrets.PYPI_API_TOKEN }}
         with:
           command: upload
+          maturin-version: "1.7.4"
           args: --non-interactive --skip-existing wheels-*/*


### PR DESCRIPTION
<!-- Edit And Paste Into Pull Request Title
Issue-<Github Issue Number>: PR Title
-->

<!--NOTE THE GITHUB ISSUES THAT THIS PR CLOSES BELOW-->
closes #

### Changes
<!-- DESCRIBE THE CHANGES YOU ARE MAKING -->
- Pins the maturin version that is used in GH actions to a specific version

### Context For Reviewers
<!-- WHY ARE YOU MAKING THIS CHANGE? -->
I saw some build failures when a new version of maturin was released today. to improve build predictability i'm pinning the maturin version to the last working version so that we don't have random failures.
